### PR TITLE
Fixed typo in output file displayed directory

### DIFF
--- a/source/.vscode/launch.json
+++ b/source/.vscode/launch.json
@@ -1,0 +1,42 @@
+{
+	"version": "0.1.0",
+	// List of configurations. Add new configurations or edit existing ones.
+	// ONLY "node" and "mono" are supported, change "type" to switch.
+	"configurations": [
+		{
+			// Name of configuration; appears in the launch configuration drop down menu.
+			"name": "Launch app.js",
+			// Type of configuration. Possible values: "node", "mono".
+			"type": "node",
+			// Workspace relative or absolute path to the program.
+			"program": "app.js",
+			// Automatically stop program after launch.
+			"stopOnEntry": false,
+			// Command line arguments passed to the program.
+			"args": [],
+			// Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.
+			"cwd": ".",
+			// Workspace relative or absolute path to the runtime executable to be used. Default is the runtime executable on the PATH.
+			"runtimeExecutable": null,
+			// Optional arguments passed to the runtime executable.
+			"runtimeArgs": ["--nolazy"],
+			// Environment variables passed to the program.
+			"env": {
+				"NODE_ENV": "development"
+			},
+			// Use JavaScript source maps (if they exist).
+			"sourceMaps": false,
+			// If JavaScript source maps are enabled, the generated code is expected in this directory.
+			"outDir": null
+		},
+		{
+			"name": "Attach",
+			"type": "node",
+			// TCP/IP address. Default is "localhost".
+			"address": "localhost",
+			// Port to attach to.
+			"port": 5858,
+			"sourceMaps": false
+		}
+	]
+}

--- a/source/workspace/bat2exe.bat
+++ b/source/workspace/bat2exe.bat
@@ -236,8 +236,7 @@ EXIT
 
 :verfile
 set vfile=
-rem set vfile=%~dp1%~nx1
-set vfile=%~n1
+set vfile=%~dp1%~nx1
 GOTO :EOF
 
 :getsize

--- a/source/workspace/bat2exe.bat
+++ b/source/workspace/bat2exe.bat
@@ -223,7 +223,7 @@ IF EXIST "%TF%\%name%.exe" (
 	echo.
 	echo       Generated File:
 	echo.
-	echo "%vfile%"
+	echo 	   "%TF%\%name%.exe"
 	echo.
 )
 echo.
@@ -236,7 +236,8 @@ EXIT
 
 :verfile
 set vfile=
-set vfile=%~dp1%~nx1
+rem set vfile=%~dp1%~nx1
+set vfile=%~n1
 GOTO :EOF
 
 :getsize


### PR DESCRIPTION
The filepath of the output exe file was missing a "\" in between the
directory and the file. I changed how it's displayed to fix the issue
